### PR TITLE
Fix configured PGID preservation for NFS access

### DIFF
--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -33,6 +33,13 @@ jobs:
         run: cd backend && uv run python -m pytest tests
 
       - name: Get Coverage Report
+        # Posting the coverage comment needs a writable GITHUB_TOKEN. Fork PRs
+        # and Dependabot runs only get a read-only token, and workflow_dispatch
+        # has no PR to comment on — skip in those cases.
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]'
         uses: orgoro/coverage@v3.3
         with:
             coverageFile: backend/coverage.xml

--- a/backend/tests/scripts/test_entrypoint_user_groups.py
+++ b/backend/tests/scripts/test_entrypoint_user_groups.py
@@ -18,6 +18,8 @@ def _run_setup_user_and_groups(identity_exists: bool) -> list[str]:
             r'''
 . "$1"
 IDENTITY_EXISTS="$2"
+PUID=1000
+PGID=1000
 source() { :; }
 box_echo() { :; }
 getent() {
@@ -32,7 +34,7 @@ getent() {
 }
 groupadd() { printf 'groupadd %s\n' "$*"; }
 useradd() { printf 'useradd %s\n' "$*"; }
-usermod() { printf '%s\n' "$*"; }
+usermod() { printf 'usermod %s\n' "$*"; }
 setup_user_and_groups
 ''',
             "bash",
@@ -49,7 +51,7 @@ setup_user_and_groups
 
 def test_existing_user_keeps_primary_group_in_supplementary_memberships() -> None:
     assert _run_setup_user_and_groups(identity_exists=True) == [
-        "-aG appuser appuser"
+        "usermod -aG appuser appuser"
     ]
 
 
@@ -57,5 +59,5 @@ def test_new_user_keeps_primary_group_in_supplementary_memberships() -> None:
     assert _run_setup_user_and_groups(identity_exists=False) == [
         "groupadd -g 1000 appuser",
         "useradd -u 1000 -g 1000 -m appuser",
-        "-aG appuser appuser",
+        "usermod -aG appuser appuser",
     ]

--- a/backend/tests/scripts/test_entrypoint_user_groups.py
+++ b/backend/tests/scripts/test_entrypoint_user_groups.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+import subprocess
+
+
+USER_GROUPS_SCRIPT = (
+    Path(__file__).resolve().parents[3]
+    / "scripts"
+    / "entrypoint"
+    / "user_groups.sh"
+)
+
+
+def _run_setup_user_and_groups(identity_exists: bool) -> list[str]:
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            r'''
+. "$1"
+IDENTITY_EXISTS="$2"
+source() { :; }
+box_echo() { :; }
+getent() {
+    if [ "$IDENTITY_EXISTS" != "true" ]; then
+        return 2
+    fi
+    case "$1" in
+        group) printf 'appuser:x:1000:\n' ;;
+        passwd) printf 'appuser:x:1000:1000::/home/appuser:/bin/sh\n' ;;
+        *) return 1 ;;
+    esac
+}
+groupadd() { printf 'groupadd %s\n' "$*"; }
+useradd() { printf 'useradd %s\n' "$*"; }
+usermod() { printf '%s\n' "$*"; }
+setup_user_and_groups
+''',
+            "bash",
+            str(USER_GROUPS_SCRIPT),
+            str(identity_exists).lower(),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    return result.stdout.splitlines()
+
+
+def test_existing_user_keeps_primary_group_in_supplementary_memberships() -> None:
+    assert _run_setup_user_and_groups(identity_exists=True) == [
+        "-aG appuser appuser"
+    ]
+
+
+def test_new_user_keeps_primary_group_in_supplementary_memberships() -> None:
+    assert _run_setup_user_and_groups(identity_exists=False) == [
+        "groupadd -g 1000 appuser",
+        "useradd -u 1000 -g 1000 -m appuser",
+        "-aG appuser appuser",
+    ]

--- a/scripts/entrypoint/user_groups.sh
+++ b/scripts/entrypoint/user_groups.sh
@@ -34,6 +34,11 @@ setup_user_and_groups() {
         useradd -u "$PUID" -g "$PGID" -m "$APPUSER"
     fi
 
+    # gosu builds the process supplementary group list from explicit /etc/group
+    # memberships. Keep the configured PGID in that list as well as the primary
+    # GID so NFS servers can authorize group-owned paths consistently.
+    usermod -aG "$APPGROUP" "$APPUSER"
+
     # Export these variables for use in other scripts
     export APPUSER
     export APPGROUP


### PR DESCRIPTION
## What changed

- Add the configured application group as an explicit membership for `appuser` before launching Trailarr through `gosu`.
- Add focused entrypoint tests for both newly created and already existing application identities.

## Why

Trailarr creates `appuser` with the configured PGID as its primary group, then adds optional device groups before launching through `gosu`. The primary-group assignment does not necessarily add the username to that group's member list in `/etc/group`, so the configured PGID can be absent from the process supplementary-group vector.

This caused a reproducible NFS authorization failure in a container configured with PUID/PGID 1000:1000: Trailarr PID 1 and refresh workers had supplementary groups 44 and 991, while the same credential with supplementary group 1000 could list the affected group-owned path. Explicitly adding `appuser` to `APPGROUP` preserves the configured PGID through `gosu` without changing the effective UID or GID.

## Impact

Users whose media paths rely on the configured PGID for NFS group authorization keep that group in Trailarr's runtime credential. Existing optional device-group behavior is unchanged.

## Validation

- Focused entrypoint tests: 2 passed.
- Complete backend suite: 718 passed on Python 3.13.5.
- `bash -n` and `git diff --check` passed.
- Built on the pinned v0.9.9 image and validated in a fresh loopback-only container with six read-only NFS binds.
- PID 1 and all captured Sonarr refresh workers retained UID/GID 1000:1000 and supplementary PGID 1000.
- The exact previously failing path listed successfully and one serialized Sonarr refresh completed without PermissionError or async-cleanup warnings.
- All write probes returned EROFS and the media metadata baseline remained byte-identical.
